### PR TITLE
Remove Theme from doc, document adding it to app

### DIFF
--- a/packages/palette/README.md
+++ b/packages/palette/README.md
@@ -10,8 +10,22 @@ yarn add @artsy/next-palette
 
 ## Usage
 
-Created a `_document.tsx` or `_document.jsx` in the root of your [pages]() directory. Add the following code:
+Create a `_document.tsx` or `_document.jsx` in the root of your [pages](https://nextjs.org/docs/basic-features/pages) directory. Add the following code:
 
 ```
 export { Document as default } from "@artsy/next-palette";
+```
+
+Next, create an `_app.tsx` or `_app.jsx` (unless you already have one), and wrap its contents in Palette's `Theme` component.
+
+```
+import { Theme } from "@artsy/palette";
+
+export default function App({ Component, pageProps }) {
+  return (
+    <Theme>
+      <Component {...pageProps}/>
+    </Theme>
+  )
+}
 ```

--- a/packages/palette/lib/document.tsx
+++ b/packages/palette/lib/document.tsx
@@ -55,9 +55,7 @@ export class Document extends NextDocument {
           {(this.props as any).styleTags}
         </Head>
         <body>
-          <Theme>
-            <Main />
-          </Theme>
+          <Main />
           <NextScript />
         </body>
       </Html>


### PR DESCRIPTION
I had added `Theme` to the `Document` component that was exported from `@artsy/next-palette` assuming that it would automatically apply the theme... I think I misunderstood how that component works though. Seems to be more of a build time artifact. 

In this PR, I removed `Theme` from `Document` and updated the documentation to point to adding it to `_app`. 